### PR TITLE
Add disableDbCleanup option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,7 @@ See [Changelog.md](Changelog.md)
  - `knex` knex instance to use. Defaults to a new knex instance, using sqlite3 with a file named 'connect-session-knex.sqlite'
  - `createtable` if the table for sessions should be created automatically or not.
  - `clearInterval` milliseconds between clearing expired sessions. Defaults to 60000.
+ - `disableDbCleanup` disables the automatic clearing of expired sessions. Defaults to false. 
 
 If the table does not exist in the schema, this module will attempt to create it unless the 'createtable' option is false.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,11 @@ module.exports = function (connect) {
       options.clearInterval = 60000;
     }
 
+    if (!options.disableDbCleanup) {
+      // Flag to prevent dbCleanup from being initialized
+      options.disableDbCleanup = false;
+    }
+
     self.createtable = Object.prototype.hasOwnProperty.call(options, 'createtable')
       ? options.createtable
       : true;
@@ -130,7 +135,7 @@ module.exports = function (connect) {
       })
       .then((exists) => {
         if (exists) {
-          dbCleanup(self, options.clearInterval, KnexStore);
+          !options.disableDbCleanup && dbCleanup(self, options.clearInterval, KnexStore);
         }
         return null;
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -334,5 +334,10 @@ module.exports = function (connect) {
     }
   };
 
+  /* fetch the dbCleanupTimeout */
+  KnexStore.prototype.getNextDbCleanup = function () {
+    return KnexStore.nextDbCleanup ? KnexStore.nextDbCleanup : null;
+  };
+
   return KnexStore;
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -32,16 +32,19 @@ stores.push(
   new KnexStore({
     db: ':memory:',
     dir: 'dbs',
+    disableDbCleanup: true
   }),
 );
 stores.push(
   new KnexStore({
     knex: knexPg,
+    disableDbCleanup: true
   }),
 );
 stores.push(
   new KnexStore({
     knex: knexMysql,
+    disableDbCleanup: true
   }),
 );
 
@@ -212,6 +215,11 @@ stores.forEach((store) => {
           },
         );
       });
+  });
+
+  test('no cleanup timeout when disableDbCleanup is true', (t) => {
+    t.equal(store.getNextDbCleanup(), null);
+    t.end();
   });
 
   test('cleanup', (t) => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,6 +8,7 @@ declare module 'connect-session-knex' {
         knex?: Knex;
         createtable?: boolean;
         clearInterval?: number;
+        disableDbCleanup?: boolean;
     };
 
     interface StoreFactory {


### PR DESCRIPTION
Ran into issue where horizontal scaling can cause session table to deadlock (and db to crash) on db cleanup. This was observed on a 3 instance deploy competing to delete stale sessions on startup. For users with similar architecture, being able to clear sessions in an externally controlled fashion (lambda job, chron, etc.) seems more reasonable than for multiple servers to potentially compete for that table. Having an option to disable db cleanup would facilitate this. 