### PR TITLE
Add Postgres support for case sensitive custom tablename

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,9 +101,9 @@ function getPostgresFastQuery(tablename, sidfieldname) {
     + '), '
     + 'upsert as '
     + '( '
-    + `  update ${
+    + `  update "${
       tablename
-    } cs set `
+    }" cs set `
     + `    ${
       sidfieldname
     } = nv.${
@@ -119,9 +119,9 @@ function getPostgresFastQuery(tablename, sidfieldname) {
     } `
     + '  returning cs.* '
     + ')'
-    + `insert into ${
+    + `insert into "${
       tablename
-    } (${
+    }" (${
       sidfieldname
     }, expired, sess) `
     + `select ${


### PR DESCRIPTION
Ran into an issue when using Postgres and case sensitive custom tablename (e.g. Sessions). Fixed the PostgreSQL upsert query to use quoted identifier for the tablename.

[Keywords and Indetifiers PostgreSQL manual](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)
