### PR TITLE
Fix default export typing for projects without `esModuleInterop` enabled

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,5 +15,6 @@ declare module 'connect-session-knex' {
         new (configs?: ConfigType): Store;
     }
 
-    export default function initFunction(session: typeof expressSession): StoreFactory;
+    function initFunction(session: typeof expressSession): StoreFactory;
+    export = initFunction;
 }


### PR DESCRIPTION
Hi! :wave:

I believe the current typing of the default export is a tiny bit off.

When the TypeScript type says `export default …`, TypeScript expects there to be an export named `default`. However, the actual export from `index.js` is just declared as `module.exports = …`.

I don't think there's any neat way to use the `export default` syntax without requiring the library's consumers to enable `esModuleInterop` in `tsconfig.json`. I'm not an expert, though 🤷‍♂️ 

With the current typing, the compiler lets me do this:

```ts
import knexSessionStore from 'connect-session-knex';
const session = /* some code */;
const KnexSessionStore = knexSessionStore(session);
```

This builds just fine. When I run the code, however, it breaks with this error message: `[ERROR] TypeError: connect_session_knex_1.default is not a function`.

I'm pretty sure the correct way of telling TypeScript that this is a `module.exports = …`-style export is to replace `export default …` with `export = …`. By changing it, the import now fails (as expected):

![image](https://user-images.githubusercontent.com/1404650/132228581-2fba1a45-1000-4f2e-a1d0-1f4451604819.png)

Instead, I can now import the module like so, which both compiles and runs:

```ts
import knexSessionStore = require('connect-session-knex');
const session = /* some code */;
const KnexSessionStore = knexSessionStore(session);
```

The `export = …` syntax requires declaring the function before exporting it, but that shouldn't make any difference.

I know a lot of projects have `esModuleInterop` enabled, but I'm trying very hard to avoid it :smile:

Do you think this looks reasonable?